### PR TITLE
Allow retrieval of all record attributes

### DIFF
--- a/src/Record.php
+++ b/src/Record.php
@@ -59,6 +59,7 @@ class Record {
     public function __get($key)
     {
         switch($key) {
+            case 'attributes':
             case 'recordId':
             case 'modId':
                 return $this->{$key};


### PR DESCRIPTION
In certain situations it is necessary to have access to the full list of attributes (an alternative solution to a simple getter would be to implement ArrayIterator and IteratorAggregate for the attributes) 