### PR TITLE
Updating guzzle dependency from v3 to v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
         }
     ],
     "require": {
-        "guzzle/guzzle": "~3"
+        "guzzlehttp/guzzle": "~6"
     },
     "autoload": {
         "psr-4": {
             "FileMaker\\": "src/"
         }
-    }
+    },
+    "prefer-stable": true
 }


### PR DESCRIPTION
The guzzle dependency being used is deprecated, this should be updated to the newest version available
